### PR TITLE
Fixed Minor and Major Flickering issues

### DIFF
--- a/space/assets/scripts/blackHole.js
+++ b/space/assets/scripts/blackHole.js
@@ -21,19 +21,23 @@ var Black_Hole = function (x,y, color){ //Constructor for the black hole object
     this.collide_right = x + 50;
     this.color = color;
     this.object_count = 0; // num of space objects it has destroyed
+    this.img = new Image(); // used to load up image once , not everytime it is drawn
 
     // sets different pull speeds based on color selection
     if (this.color == 0) { //purple
         this.pull_speed = 2;
         this.capacity = 2;
+        this.img.src = "assets/images/portalpurple.svg";
 
     } else if (this.color == 2) { // red
         this.pull_speed = 3;
         this.capacity = 1;
+        this.img.src = "assets/images/portalblack.svg";
 
     } else if (this.color == 1) { //blue
         this.pull_speed = 1;
         this.capacity = 3;
+        this.img.src = "assets/images/portalblue.svg";
     }
 }
 
@@ -92,31 +96,17 @@ function calculateSpeed(blackhole, spaceobject) {
 function drawHole(hole){
     var canvas = document.getElementById("space-canvas");
     var context = canvas.getContext("2d");
-    var img = new Image();
-    switch(hole.color){
-        case 0: window.ctx.fillStyle = "purple";
-            img.src = "assets/images/portalpurple.svg";
-            break;
-        case 1: window.ctx.fillStyle = "blue";
-            img.src = "assets/images/portalblue.svg";
-            break;
-        case 2: window.ctx.fillStyle = "red";
-            img.src = "assets/images/portalblack.svg";
-            break;
-    }
-    img.onload = function() {
-        ctx.drawImage(img, hole.x-25, hole.y-25);
-    }
+    ctx.drawImage(hole.img, hole.x-25, hole.y-25);
     // window.ctx.beginPath();
     // window.ctx.arc(hole.x,hole.y, 25, 0, 2* Math.PI, false);
     // window.ctx.fill();
     //window.ctx.strokeStyle = "white";
     //window.ctx.stroke();
-    window.ctx.fillStyle="black";
-    window.ctx.beginPath();
-    window.ctx.strokeRect(hole.click_left, hole.click_top,  50, 50);
-    window.ctx.beginPath();
-    window.ctx.strokeRect(hole.collide_left, hole.collide_top, 100,100);
+    //window.ctx.fillStyle="black";
+    //window.ctx.beginPath();
+    //window.ctx.strokeRect(hole.click_left, hole.click_top,  50, 50);
+    //window.ctx.beginPath();
+    //window.ctx.strokeRect(hole.collide_left, hole.collide_top, 100,100);
 }
 
 function clearHole(hole){

--- a/space/assets/scripts/blackHole.js
+++ b/space/assets/scripts/blackHole.js
@@ -50,11 +50,16 @@ Black_Hole.prototype.pull = function(spaceobjects, game) {
             game.score -= 50;
 
             this.object_count += 1;
-            
-            if (this.object_count == this.capacity) {
-                var index = game.blackHoleArray.indexOf(this);
-                game.blackHoleArray.splice(index, 1);
-            }
+            var g = game;
+            var that = this;
+            setTimeout(function() {
+
+                if (that.object_count == that.capacity) {
+                    var index = g.blackHoleArray.indexOf(that);
+                    g.blackHoleArray.splice(index, 1);
+                }
+                
+            }, 0);
         }
     }
 };

--- a/space/assets/scripts/gameManager.js
+++ b/space/assets/scripts/gameManager.js
@@ -204,8 +204,8 @@ function createHUD(game) {
 function spawnSpaceObject() {
 	var temp = new SpaceObject(0,0,0);
 
-	var x_pos = Math.floor((Math.random()*900) + temp.width/2);
-	var y_pos = Math.floor((Math.random()*540) + 42 + temp.width/2);
+	var x_pos = Math.floor((Math.random()*800) + 100);
+	var y_pos = Math.floor((Math.random()*440) + 100);
 	var type = Math.floor((Math.random()*4));
 
 	return new SpaceObject(x_pos, y_pos, type);


### PR DESCRIPTION
when multiple blackholes are on the screen and one is removed due to reaching its capacity, another would flicker because of the array that is being updated before animation frame is finished drawing. I used timeout function with 0 to move it's execution to the end of animate function when all blackholes have been drawn to canvas.

also fixed major flickering with svg images. instead of loading image file for each frame. Load it once when creating blackhole object, then call drawImage function for each frame